### PR TITLE
Support Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example Playbook
 License
 -------
 
-LGPL.
+LGPL-3.0
 
 Author Information
 ------------------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install UWF (Uncomplicated Firewall)
 Requirements
 ------------
 
-Debian Wheezy/Jessie with the package python-pycurl and python-software-properties installed.
+Debian Wheezy/Jessie/Stretch with the package python-pycurl and python-software-properties installed.
 
 Example Playbook
 -------------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Jasper N. Brouwer, Ramon de la Fuente"
   description: "Install UWF (Uncomplicated Firewall)"
   company: Future500
-  license: LGPL
+  license: LGPL-3.0
   min_ansible_version: 1.6
   platforms:
   - name: Debian

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: "Install UWF (Uncomplicated Firewall)"
   company: Future500
   license: LGPL
-  min_ansible_version: 1.4
+  min_ansible_version: 1.6
   platforms:
   - name: Debian
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
     versions:
       - wheezy
       - jessie
+      - stretch
   categories:
     - system
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 
 - name: install ufw
-  apt: pkg=ufw state=present
+  apt:
+    name: ufw
+    state: present
 
 - name: enable and start ufw
-  command: ufw -f enable
+  ufw:
+    state: enabled


### PR DESCRIPTION
Use the `ufw` module in Ansible core.
Add up to Stretch to supported Debian versions & Specify license version (LGPL-3.0).

After merge I recommend tagging `v3.0.0`.
