### PR TITLE
Merge ufw_rules tasks into this role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,58 @@
-Ufw
-========
+UFW
+===
 
-Install UWF (Uncomplicated Firewall)
+Install UWF (Uncomplicated Firewall) and create (or remove) rules.
 
 Requirements
 ------------
 
 Debian Wheezy/Jessie/Stretch with the package python-pycurl and python-software-properties installed.
 
+Role Variables
+--------------
+
+Set the default policy:
+
+    ufw_default_policy: deny
+
+Add or remove rules:
+
+    ufw_rules_to_create: []
+    ufw_rules_to_delete: []
+
+Both `ufw_rules_to_create` and `ufw_rules_to_delete` accept a list of dictionaries, like so:
+
+    ufw_rules_to_create:
+      - direction: in
+        from_ip: 1.2.3.4
+        from_port: 5678
+        interface: eth0
+        proto: tcp
+        rule: allow
+        to_ip: 5.6.7.8
+        to_port: 1234
+
 Example Playbook
--------------------------
+----------------
 
     - hosts: servers
       roles:
-         - { role: f500.ufw }
+         - role: f500.ufw
+           ufw_rules_to_create:
+             - { to_port: 22 }
+             - { to_port: 80 }
+             - { to_port: 443 }
 
 License
 -------
 
-LGPL-3.0
+Copyright (C) 2017 Future500 B.V.
+
+[LGPL-3.0](https://github.com/f500/ansible-ufw/blob/master/COPYING.LESSER)
 
 Author Information
 ------------------
 
-Jasper N. Brouwer, jasper@nerdsweide.nl
+Jasper N. Brouwer, jasper@future500.nl
 
-Ramon de la Fuente, ramon@delafuente.nl
+Ramon de la Fuente, ramon@future500.nl

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+ufw_rules_to_create: []
+ufw_rules_to_delete: []
+
+ufw_default_policy: deny

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,6 @@ galaxy_info:
       - wheezy
       - jessie
       - stretch
-  categories:
+  galaxy_tags:
     - system
-dependencies: []
+    - security

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,35 @@
     name: ufw
     state: present
 
+- name: create rules
+  ufw:
+    direction: "{{ item.direction|default(omit) }}"
+    from_ip: "{{ item.from_ip|default(omit) }}"
+    from_port: "{{ item.from_port|default(omit) }}"
+    interface: "{{ item.interface|default(omit) }}"
+    proto: "{{ item.proto|default(omit) }}"
+    rule: "{{ item.rule|default('allow') }}"
+    to_ip: "{{ item.to_ip|default(omit) }}"
+    to_port: "{{ item.to_port|default(omit) }}"
+  with_items: "{{ ufw_rules_to_create }}"
+
+- name: delete rules
+  ufw:
+    direction: "{{ item.direction|default(omit) }}"
+    from_ip: "{{ item.from_ip|default(omit) }}"
+    from_port: "{{ item.from_port|default(omit) }}"
+    interface: "{{ item.interface|default(omit) }}"
+    proto: "{{ item.proto|default(omit) }}"
+    rule: "{{ item.rule|default('allow') }}"
+    to_ip: "{{ item.to_ip|default(omit) }}"
+    to_port: "{{ item.to_port|default(omit) }}"
+    delete: yes
+  with_items: "{{ ufw_rules_to_delete }}"
+
+- name: set default policy
+  ufw:
+    policy: "{{ ufw_default_policy }}"
+
 - name: enable and start ufw
   ufw:
     state: enabled


### PR DESCRIPTION
This role can now create/remove rules, and deprecates the `f500.ufw_rules` role.

Please tag as `v4.0.0` after merging.