### PR TITLE
Add direction to the default policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Role Variables
 
 Set the default policy:
 
-    ufw_default_policy: deny
+    ufw_default_policy:
+      - { direction: "incoming", policy: "deny" }
+
 
 Add or remove rules:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,6 @@
 ufw_rules_to_create: []
 ufw_rules_to_delete: []
 
-ufw_default_policy: deny
+ufw_default_policy:
+  - { direction: "incoming", policy: "deny" }
+  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,9 @@
 
 - name: set default policy
   ufw:
-    policy: "{{ ufw_default_policy }}"
+    policy: "{{ item.policy }}"
+    direction: "{{ item.direction }}"
+  with_items: "{{ ufw_default_policy }}"
 
 - name: enable and start ufw
   ufw:


### PR DESCRIPTION
The Ansible UFW command requires a direction set failing in doing so results in an error:
https://github.com/ansible/ansible/commit/4d3d8dd60f91a1c68bca55824fb88a72bf8eb718#diff-476edcbbb72b9029f5b116b4c813c076
'For default, direction must be one of "outgoing", "incoming" and "routed".'

This PR fixes just that by setting a list for as default denying incoming and outgoing traffic.